### PR TITLE
Bump ch.qos.logback:logback-core from 1.2.3 to 1.2.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.2.3</version>
+      <version>1.2.9</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Bumps ch.qos.logback:logback-core from 1.2.3 to 1.2.9.

---
updated-dependencies:
- dependency-name: ch.qos.logback:logback-core dependency-type: direct:production ...